### PR TITLE
fix composer json (version number and typo3 core depency)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "sjbr/static_info_tables_de",
   "description": "German (de) language pack for the Static Info Tables providing localized names for countries, currencies and so on.",
-  "version": "6.3.1",
+  "version": "6.5.0",
   "type": "typo3-cms-extension",
   "license": "GPL-2.0+",
   "authors": [
@@ -14,7 +14,7 @@
     "sjbr/static_info_tables_de": "*"
   },
   "require": {
-    "typo3/cms-core": "6.2.0-7.0.99",
+    "typo3/cms-core": ">=6.2.0,<8.9.99",
     "sjbr/static_info_tables": "^6.3.1"
   }
 }


### PR DESCRIPTION
make the config in composer.json equal to the ext_emconf.php