### PR TITLE
Add compatibility with TYPO3 10

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Classes.php
+ *
+ * @author Klaus Fiedler <klaus@tollwerk.de> / @jkphl
+ * @copyright Copyright © 2019 Klaus Fiedler <klaus@tollwerk.de>
+ * @license http://opensource.org/licenses/MIT The MIT License (MIT)
+ */
+
+/***********************************************************************************
+ *  The MIT License (MIT)
+ *
+ *  Copyright © 2019 Klaus Fiedler <klaus@tollwerk.de>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ***********************************************************************************/
+
+
+declare(strict_types=1);
+return [
+    \SJBR\StaticInfoTables\Domain\Model\Country::class => [
+        'tableName' => 'static_countries',
+        'properties' => [
+            'shortNameDe' => [
+                'fieldName' => 'cn_short_de',
+            ],
+        ], 
+    ],
+    \SJBR\StaticInfoTables\Domain\Model\CountryZone::class => [
+        'tableName' => 'static_country_zones',
+        'properties' => [
+            'nameDe' => [
+                'fieldName' => 'zn_name_de',
+            ],
+        ],
+    ],
+    \SJBR\StaticInfoTables\Domain\Model\Currency::class => [
+        'tableName' => 'static_currencies',
+        'properties' => [
+            'nameDe' => [
+                'fieldName' => 'cu_name_de',
+            ],
+            'subdivisionNameDe' => [
+                'fieldName' => 'cu_sub_name_de',
+            ],
+        ],
+    ],
+    \SJBR\StaticInfoTables\Domain\Model\Language::class => [
+        'tableName' => 'static_languages',
+        'properties' => [
+            'nameDe' => [
+                'lg_name_de' => 'cu_name_de',
+            ],
+        ],
+    ],
+    \SJBR\StaticInfoTables\Domain\Model\Territory::class => [
+        'tableName' => 'static_territories',
+        'properties' => [
+            'nameDe' => [
+                'tr_name_de' => 'cu_name_de',
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
Hi! This fork now is compatible with TYPO3 10 as well as older versions: I migrated the `config.persistence.classes` settings from *ext_typoscript_setup.txt* to */Configuration/Extbase/Persistence/Classes.php*. 

See here:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-87623-ReplaceConfigpersistenceclassesTyposcriptConfiguration.html

**Important:**
Right now, those settings MUST stay inside the *ext_typoscript_setup.txt* as well in order for `getNameLocalized()` to work. As far as I understand it that's not an issue with static_info_tables but with the TYPO3 ConfigurationManager method `getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK)`. 

I updated static_info_tables as well and will try to contribute the changes as well.