### PR TITLE
[CLEANUP] Stop using `$_EXTKEY`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF[$_EXTKEY] = Array (
+$EM_CONF['static_info_tables_de'] = array(
     'title' => 'Static Info Tables (de)',
     'description' => 'German (de) language pack for the Static Info Tables providing localized names for countries, currencies and so on.',
     'category' => 'misc',


### PR DESCRIPTION
It is not recommended to use this variable anymore.