### PR TITLE
Fix dependency on addons_em

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "typo3/cms-core": "^10.4 || ^11.5 || ^12.3",
     "sjbr/static-info-tables": "^6.9 || ^11.5 || ^12.3",
-    "jambagecom/addons-em": "^0.6"
+    "jambagecom/addons-em": "^0.8"
   },
   "extra": {
     "typo3/cms": {


### PR DESCRIPTION
With TYPO3 12 we need jambagecom/addons-em in Version 0.8 since Version 0.6 requires TYPO3 ^9.5 || ^10.4 || ^11.5

`jambagecom/addons-em v0.6.0 requires typo3/cms-core ^9.5 || ^10.4 || ^11.5 -> found typo3/cms-core[v9.5.0, ..., v9.5.31, v10.4.0, ..., v10.4.37, v11.5.0, ..., v11.5.30] but it conflicts with your root composer.json require (^12.4).`